### PR TITLE
fix: strip component name from HOCs. add types (wip)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ resq$$(selector: string, element?: HTMLElement): Array<RESQNode>
 * [Basic Usage](README.md#basic-usage)
 * [Wildcard selection](README.md#wildcard-selection)
 * [Async selection](README.md#async-selection)
-* [Styled Components & MaterialUI](README.md#styled-components--materialui)
 * [Filtering selection](README.md#filtering-selection)
 
 #### Basic Usage
@@ -171,38 +170,7 @@ async function getReactElement(name) {
 getReactElement('MyComponent')
 ```
 
-#### Styled Components & MaterialUI
-For selecting Styled components or MaterialUI components, we **strongly** recommend you use React DevTools to see the component structure in your browser in order to more easily understand the name of the components once the libraries compile them.
 
-Example app:
-
-```jsx
-// imports
-const App = () => (
-  <Container>
-      <Paper>
-          <Box component="span">
-            <Link>tick</Link>
-          </Box>
-      </Paper>
-    </Container>
-)
-
-ReactDOM.render(
-  <ThemeProvider theme={theme}>
-    <App/>
-  </ThemeProvider>,
-  document.querySelector('#root')
-)
-```
-
-To select the `Box` component:
-
-```js
-import { resq$ } from 'resq'
-
-resq$('Styled(MuiBox)', document.querySelector('#root'))
-```
 #### Filtering selection
 
 You can filter your selections `byState` or `byProps`. These are methods attached to the RESQNode return objects.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,23 @@
+type NotFunc<T> = Exclude<T, Function>
+
+declare namespace RESQ {
+    interface RESQNode {
+        name: 'MyComponent',
+        node: HTMLElement | null,
+        isFragment: boolean,
+        state: NotFunc<any>,
+        props: {},
+        children: RESQNode[]
+        private _nodes: Array<RESQ>
+    }
+
+    type waitToLoadReact = (timeInMs: number) => Promise
+    type resq$ = (selector: string, element?: HTMLElement) => RESQNode
+    type resq$$ = (selector: string, element?: HTMLElement) => Array<RESQNode>
+}
+
+declare var resq$: RESQ.resq$
+declare var resq$$: RESQ.resq$
+declare module "resq" {
+    export = RESQ
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ type NotFunc<T> = Exclude<T, Function>
 
 declare namespace RESQ {
     interface RESQNode {
-        name: 'MyComponent',
+        name: string,
         node: HTMLElement | null,
         isFragment: boolean,
         state: NotFunc<any>,
@@ -11,13 +11,13 @@ declare namespace RESQ {
         private _nodes: Array<RESQ>
     }
 
-    type waitToLoadReact = (timeInMs: number) => Promise
+    type waitToLoadReact = (timeInMs?: number, rootElSelector?: string) => Promise<null | string>
     type resq$ = (selector: string, element?: HTMLElement) => RESQNode
     type resq$$ = (selector: string, element?: HTMLElement) => Array<RESQNode>
 }
 
 declare var resq$: RESQ.resq$
-declare var resq$$: RESQ.resq$
+declare var resq$$: RESQ.resq$$
 declare module "resq" {
     export = RESQ
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -37,13 +37,15 @@ function findStateNode(element) {
 }
 
 function stripHoCFromName(componentName) {
-    const splitName = componentName.split('(')
+    if (componentName) {
+        const splitName = componentName.split('(')
 
-    if (splitName.length === 1) {
-        return componentName
+        if (splitName.length === 1) {
+            return componentName
+        }
+
+        return splitName.find(e => e.includes(')')).replace(/\)*/g, '')
     }
-
-    return splitName.find(e => e.includes(')')).replace(/\)*/g, '')
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -36,7 +36,7 @@ function findStateNode(element) {
     return null
 }
 
-function stripHoCFromName(componentName) {
+export function stripHoCFromName(componentName) {
     if (componentName) {
         const splitName = componentName.split('(')
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -36,6 +36,16 @@ function findStateNode(element) {
     return null
 }
 
+function stripHoCFromName(componentName) {
+    const splitName = componentName.split('(')
+
+    if (splitName.length === 1) {
+        return componentName
+    }
+
+    return splitName.find(e => e.includes(')')).replace(/\)*/g, '')
+}
+
 /**
  * @name removeChildrenFromProps
  * @param {Object | String}
@@ -246,8 +256,12 @@ export function findInTree(stack, searchFn) {
  * @description Check is node name match to selector
  */
 export function matchSelector(selector, nodeName) {
+    const strippedName = stripHoCFromName(nodeName)
     const escapeRegex = (nodeName) => nodeName.replace(/([.*+?^=!:${}()|[\]/\\])/g, '\\$1')
-    return new RegExp('^' + selector.split('*').map(escapeRegex).join('.+') + '$').test(nodeName)
+
+    return new RegExp('^' + selector.split('*')
+        .map(escapeRegex).join('.+') + '$')
+        .test(strippedName)
 }
 
 /**

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -8,6 +8,7 @@ import {
     verifyIfObjectsMatch,
     findReactInstance,
     matchSelector,
+    stripHoCFromName,
 } from '../src/utils'
 
 import {
@@ -615,6 +616,12 @@ describe('utils', () => {
 
         it('should return undefined if no instance is found', () => {
             expect(findReactInstance(document.createElement('div'))).toBeFalsy()
+        })
+    })
+
+    describe('stripHoCFromName', () => {
+        it('should not do anyting if component name is missing', () => {
+            expect(stripHoCFromName()).toBe(undefined)
         })
     })
 })

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -261,12 +261,12 @@ describe('utils', () => {
                 match: true,
             },
             {
-                selector: 'node_with(special_characters)',
+                selector: 'special_characters',
                 nodeName: 'node_with(special_characters)',
                 match: true,
             },
             {
-                selector: 'node_with*',
+                selector: 'special_chara*',
                 nodeName: 'node_with(special_characters)',
                 match: true,
             },


### PR DESCRIPTION
#43 

This PR is a quick fix for selecting components with HoCs.

It might introduce breaking changes if the user is selecting wrapped components with their HoC name.

```js
resq$('someWrapper(anotherHoc(MyComponent))') // doesn't work
resq$('MyComponent') // works
```