### PR TITLE
Add null check to verifyIfObjectsMatch

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -131,7 +131,7 @@ export function verifyIfObjectsMatch(matcher = {}, verify = {}, exact = false) {
     }
 
     keys(matcher).forEach((key) => {
-        if (verify.hasOwnProperty(key)) {
+        if (verify !== null && verify.hasOwnProperty(key)) {
             if (isNativeObject(matcher[key]) && isNativeObject(verify[key])) {
                 results = results.concat(verifyIfObjectsMatch(matcher[key], verify[key]))
             }


### PR DESCRIPTION
This was causing some trouble for me in my Cypress tests. They use cypress-react-selector, which is dependant on resq. I'm not sure exactly what is causing the argument to be null, but this seemed like the easiest fix.