### PR TITLE
Add null check to verifyIfObjectsMatch

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -126,12 +126,16 @@ export function verifyIfObjectsMatch(matcher = {}, verify = {}, exact = false) {
         return true
     }
 
+    if (verify === null) {
+        return false;
+    }
+
     if (exact) {
         return deepEqual(matcher, verify)
     }
 
     keys(matcher).forEach((key) => {
-        if (verify !== null && verify.hasOwnProperty(key)) {
+        if (verify.hasOwnProperty(key)) {
             if (isNativeObject(matcher[key]) && isNativeObject(verify[key])) {
                 results = results.concat(verifyIfObjectsMatch(matcher[key], verify[key]))
             }

--- a/src/utils.js
+++ b/src/utils.js
@@ -131,7 +131,7 @@ export function verifyIfObjectsMatch(matcher = {}, verify = {}, exact = false) {
     }
 
     keys(matcher).forEach((key) => {
-        if (verify.hasOwnProperty(key)) {
+        if (verify !== null && verify.hasOwnProperty(key)) {
             if (isNativeObject(matcher[key]) && isNativeObject(verify[key])) {
                 results = results.concat(verifyIfObjectsMatch(matcher[key], verify[key]))
             }

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,7 +127,7 @@ export function verifyIfObjectsMatch(matcher = {}, verify = {}, exact = false) {
     }
 
     if (verify === null) {
-        return false;
+        return false
     }
 
     if (exact) {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -557,6 +557,18 @@ describe('utils', () => {
             expect(verifyIfObjectsMatch({}, { a: 1 })).toBeTruthy()
         })
 
+        it('should return false if verify is null', () => {
+            const m1 = { };
+            const m2 = { bar: true };
+            const v1 = null;
+            const v2 = { bar: true };
+
+            expect(verifyIfObjectsMatch(m2, v1)).toBeFalsy();
+            expect(verifyIfObjectsMatch(m2, v2)).toBeTruthy();
+            expect(verifyIfObjectsMatch(m1, v2)).toBeTruthy();
+            expect(verifyIfObjectsMatch(m1, v1)).toBeTruthy();
+        })
+
         it('should do simple matches', () => {
             const matcher = [
                 { a: undefined, b: undefined },

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -558,15 +558,15 @@ describe('utils', () => {
         })
 
         it('should return false if verify is null', () => {
-            const m1 = { };
-            const m2 = { bar: true };
-            const v1 = null;
-            const v2 = { bar: true };
+            const m1 = { }
+            const m2 = { bar: true }
+            const v1 = null
+            const v2 = { bar: true }
 
-            expect(verifyIfObjectsMatch(m2, v1)).toBeFalsy();
-            expect(verifyIfObjectsMatch(m2, v2)).toBeTruthy();
-            expect(verifyIfObjectsMatch(m1, v2)).toBeTruthy();
-            expect(verifyIfObjectsMatch(m1, v1)).toBeTruthy();
+            expect(verifyIfObjectsMatch(m2, v1)).toBeFalsy()
+            expect(verifyIfObjectsMatch(m2, v2)).toBeTruthy()
+            expect(verifyIfObjectsMatch(m1, v2)).toBeTruthy()
+            expect(verifyIfObjectsMatch(m1, v1)).toBeTruthy()
         })
 
         it('should do simple matches', () => {


### PR DESCRIPTION
This was causing some trouble for me. To give some context, I encountered this in my Cypress tests using cypress-react-selector, which is dependent on resq. I'm not sure exactly what is causing the argument to be null, but this seemed like the easiest fix.
