### PR TITLE
React in iframe

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import ReactSelectorQuery from './src/resq'
-import { waitToLoadReact } from './src/waitToLoadReact'
+import { waitToLoadReact, waitToLoadReactPlayerWeb } from './src/waitToLoadReact'
 import { findReactInstance } from './src/utils'
 
 function doQuery(selector, method, element) {
@@ -28,4 +28,4 @@ export function resq$$(selector, element) {
     return doQuery(selector, 'findAll', element)
 }
 
-export { waitToLoadReact }
+export { waitToLoadReact, waitToLoadReactPlayerWeb }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import ReactSelectorQuery from './src/resq'
-import { waitToLoadReact, waitToLoadReactPlayerWeb } from './src/waitToLoadReact'
+import { waitToLoadReact, waitToLoadReactInIframe } from './src/waitToLoadReact'
 import { findReactInstance } from './src/utils'
 
 function doQuery(selector, method, element) {
@@ -28,4 +28,4 @@ export function resq$$(selector, element) {
     return doQuery(selector, 'findAll', element)
 }
 
-export { waitToLoadReact, waitToLoadReactPlayerWeb }
+export { waitToLoadReact, waitToLoadReactInIframe }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "resq",
-    "version": "1.10.1",
-    "description": "React Element Selector Query (resq) - Query React components and children by selector (component name)",
+    "name": "enhanced-resq",
+    "version": "1.0.0",
+    "description": "React Element Selector Query Enhanced - Query React components and children by selector (component name), starting also from an iFrame",
     "keywords": [
         "react",
         "selector",
@@ -10,7 +10,7 @@
         "queryselector",
         "query"
     ],
-    "author": "Baruch Velez <baruchvelez@gmail.com>",
+    "author": "Alessandro Defendenti (Radicalbit S.r.l.)",
     "license": "MIT",
     "main": "dist/index.js",
     "bugs": {

--- a/src/waitToLoadReact.js
+++ b/src/waitToLoadReact.js
@@ -55,7 +55,7 @@ export function waitToLoadReactInIframe(timeout = 5000, iFrameElSelector, rootEl
     }
 
     const findReactRoot = () => {
-        if (iFrameElSelector) {
+        if (iFrameElSelector && rootElSelector) {
             return document
                 .querySelector(iFrameElSelector)
                 .contentWindow

--- a/src/waitToLoadReact.js
+++ b/src/waitToLoadReact.js
@@ -49,17 +49,27 @@ export function waitToLoadReact(timeout = 5000, rootElSelector) {
     })
 }
 
-export function waitToLoadReactPlayerWeb(timeout = 5000) {
+export function waitToLoadReactInIframe(timeout = 5000, iFrameElSelector, rootElSelector) {
     if (global.isReactLoaded) {
         return Promise.resolve('React already loaded')
     }
 
     const findReactRoot = () => {
-        return document
-            .querySelector('html > body > div > iframe')
-            .contentWindow
-            .document
-            .querySelector('#root')
+        if (iFrameElSelector) {
+            return document
+                .querySelector(iFrameElSelector)
+                .contentWindow
+                .document
+                .querySelector(rootElSelector)
+        }
+
+        const walker = document.createTreeWalker(document)
+
+        while(walker.nextNode()) {
+            if (walker.currentNode.hasOwnProperty('_reactRootContainer')) {
+                return walker.currentNode
+            }
+        }
     }
 
     return new Promise((resolve, reject) => {

--- a/src/waitToLoadReact.js
+++ b/src/waitToLoadReact.js
@@ -48,3 +48,46 @@ export function waitToLoadReact(timeout = 5000, rootElSelector) {
         }, timeout)
     })
 }
+
+export function waitToLoadReactPlayerWeb(timeout = 5000) {
+    if (global.isReactLoaded) {
+        return Promise.resolve('React already loaded')
+    }
+
+    const findReactRoot = () => {
+        return document
+            .querySelector('html > body > div > iframe')
+            .contentWindow
+            .document
+            .querySelector('#root')
+    }
+
+    return new Promise((resolve, reject) => {
+        let timedout = false
+
+        const tryToFindApp = () => {
+            const reactRoot = findReactRoot()
+
+            if (reactRoot) {
+                global.isReactLoaded = true
+                global.rootReactElement = findReactInstance(reactRoot)
+                return resolve()
+            }
+            /* istanbul ignore next */
+            if (timedout) {
+                return
+            }
+
+            setTimeout(tryToFindApp, 200)
+        }
+
+        tryToFindApp()
+
+        /* istanbul ignore next */
+        setTimeout(() => {
+            timedout = true
+
+            reject('Timed out')
+        }, timeout)
+    })
+}


### PR DESCRIPTION
If the react application is managed within an iframe, the `document.querySelector(rootElSelector)` is not enough.

**GOAL**: Add a way to select React's root element in an iframe

**WORK DONE**: Implemented a new `waitToLoadReactInIframe` method that accepts both the iframe selector and the root selector and returns the iframe selector