### PR TITLE
Handle advanced naming cases

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -288,6 +288,10 @@ export function findSelectorInTree(selectors, tree, selectFirst = false, searchF
                 if (typeof child.name === 'string') {
                     return matchSelector(selector, child.name)
                 } else if (child.name !== null && typeof child.name === 'object') {
+                    if (child.name.render !== undefined && child.name.render.name !== null &&
+                        typeof child.name.render.name === 'string') {
+                        return matchSelector(selector, child.name.render.name)
+                    }
                     return matchSelector(selector, child.name.displayName)
                 }
 


### PR DESCRIPTION
In some frameworks such as Material UI the name is indeed in a name object properties but usually masquerades inside the renderer function.
I've pointed to analyzing the render function name as a possible match.
![image](https://user-images.githubusercontent.com/57095228/130864076-2194a4ec-27a4-48aa-ba51-434c41ee8c6e.png)

Maybe in the future we can create a new signature of the match function where you can specify which nested property within the component name might hold the name of the component instead of hard coding it.
This is somewhat related to https://github.com/baruchvlz/resq/issues/17 but not quite.
We found that in many cases React Dev Tools will display the proper name of the component but I could still not find it with resq.
I think React DevTools is using something similar to resolve the component name even when it's a renderer function.
![image](https://user-images.githubusercontent.com/57095228/130864471-f81227b2-74cf-4d43-adc4-97a839defee8.png)
FYI: @baruchvlz  and @christian-bromann 