### PR TITLE
feat: add support for React 18

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -331,7 +331,8 @@ export function findReactInstance(element) {
     }
 
     const instanceId = Object.keys(element).find(
-        key => key.startsWith('__reactInternalInstance') || key.startsWith('__reactFiber')
+        key => key.startsWith('__reactInternalInstance') || key.startsWith('__reactFiber') ||
+          key.startsWith('__reactContainer')
     )
 
     if (instanceId) {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -643,6 +643,14 @@ describe('utils', () => {
             expect(findReactInstance(element)).toBeTruthy()
         })
 
+        it('should work with React 18', () => {
+            const element = {
+                __reactContainer$test1234: true,
+            }
+
+            expect(findReactInstance(element)).toBeTruthy()
+        })
+
         it('should return undefined if no instance is found', () => {
             expect(findReactInstance(document.createElement('div'))).toBeFalsy()
         })


### PR DESCRIPTION
Hi!

There seems to be issues with React 18 and Web Components / Shadow Roots / Redux States.
This makes it so that React components are prefixed with `__reactContainer` instead of `__reactFiber`.
(Source: https://javascript.plainenglish.io/how-to-get-the-redux-state-in-a-react-18-production-build-via-the-browsers-console-a01814eebfa8)

This fix will alleviate this issue.

Hopefully we can get this merged.

Thanks!