### PR TITLE
fix react 18 in legacy mode: _reactRootContainer might still be defined

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -326,7 +326,10 @@ export function filterNodesBy(nodes, key, matcher, exact = false) {
  * @return {FiberNode}
  */
 export function findReactInstance(element) {
-    if (element.hasOwnProperty('_reactRootContainer')) {
+    if (
+        element.hasOwnProperty('_reactRootContainer') &&
+        element._reactRootContainer._internalRoot
+    ) {
         return element._reactRootContainer._internalRoot.current
     }
 

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -651,6 +651,15 @@ describe('utils', () => {
             expect(findReactInstance(element)).toBeTruthy()
         })
 
+        it('should work with React 18 legacy', () => {
+            const element = {
+                _reactRootContainer: {},
+                __reactContainer$test1234: true,
+            }
+
+            expect(findReactInstance(element)).toBeTruthy()
+        })
+
         it('should return undefined if no instance is found', () => {
             expect(findReactInstance(document.createElement('div'))).toBeFalsy()
         })


### PR DESCRIPTION
If you're running React 18, but using the legacy API's still, _reactRootContainer is undefined, but it doesn't have the _internalRoot property on it. This should fix that – in React 18 legacy, we want to follow the React 18 path for finding the react instance, ideally.

You can see the problem here: https://codepen.io/cyberdash/pen/oNJLaeo?editors=1111
